### PR TITLE
Bug Fix Player Marbles Falling Off Board

### DIFF
--- a/Assets/Scripts/Marble Scripts/MarbleController.cs
+++ b/Assets/Scripts/Marble Scripts/MarbleController.cs
@@ -37,6 +37,8 @@ public class MarbleController : MonoBehaviour
     private SceneController _sceneController;
     private bool _isDead = false;
 
+    private bool _activateBarrier = false;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -82,7 +84,16 @@ public class MarbleController : MonoBehaviour
 
     private void FixedUpdate()
     {
-        if(_rigidBody.IsSleeping() && _currentState == State.INACTIVE && !_isDead)
+        //Only active when marble has been shot AND barrier is up
+        if (_currentState == State.INACTIVE && _activateBarrier)
+        {
+            if (transform.position.z < -2.7f)
+            {
+                _rigidBody.Sleep();
+            }
+        }
+
+        if (_rigidBody.IsSleeping() && _currentState == State.INACTIVE && !_isDead)
         {
             _isDead = true;
             _sceneController.EndTurn();
@@ -166,7 +177,16 @@ public class MarbleController : MonoBehaviour
             Destroy(_powerMarker);
 
             _currentState = State.INACTIVE;
+            StartCoroutine(ActivateBarrierTimer());
         }        
+    }
+
+    IEnumerator ActivateBarrierTimer()
+    {
+        //After 0.1 seconds, activate barrier to prevent 
+        //marbles from falling off the back of the board
+        yield return new WaitForSeconds(0.1f);
+        _activateBarrier = true;
     }
 
     public void SetHat(GameObject hat)


### PR DESCRIPTION
Player marbles can no longer fall off the back of the board. Implementation is a coroutine that waits 0.1 seconds before setting a bool to true. That bool is checked during FixedUpdate(), such that when it is true, if the marble hits -2.7 on the X axis, it will be immediately put to sleep. This does not interfere with the next player's turn in any game breaking way.

Fixed #31 